### PR TITLE
Updates dry-configurable breaking change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     devise-fireauth (0.1.0.rc1)
       activesupport (>= 4)
       devise (~> 4.0)
-      dry-configurable
+      dry-configurable (>= 0.13)
       jwt (>= 1)
       warden
 
@@ -351,4 +351,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.3.18
+   2.3.24

--- a/devise-fireauth.gemspec
+++ b/devise-fireauth.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activesupport", ">= 4"
   spec.add_runtime_dependency "devise", "~> 4.0"
-  spec.add_runtime_dependency "dry-configurable"
+  spec.add_runtime_dependency "dry-configurable", ">= 0.13"
   spec.add_runtime_dependency "jwt", ">= 1"
   spec.add_runtime_dependency "warden"
 

--- a/lib/devise/fireauth.rb
+++ b/lib/devise/fireauth.rb
@@ -14,7 +14,7 @@ module Devise
     extend Dry::Configurable
 
     setting :api_key, reader: true
-    setting :token_key, :id_token, reader: true
+    setting :token_key, default: :id_token, reader: true
     setting :project_id, reader: true
 
     # Firebase Validator


### PR DESCRIPTION
Hi! 👋  
Just received a dry-configurable update from rubocop in one project and this gem is incompatible.

Looks like default settings configuration was changed in [v0.15](https://github.com/dry-rb/dry-configurable/commit/06ab2f0890d62c7e75ca06a9948fe661b0b359b7) and finally removed on [v0.16](https://github.com/dry-rb/dry-configurable/compare/v0.15.0...v0.16.0)

This PR is addresses this change.

⚠️ Removes support for dry-configurable versions below v0.13 (the oldest version where the default definition through keyword is accepted)